### PR TITLE
API data types as a proxy for data types defined in sps_objects.hpp

### DIFF
--- a/libraries/plugins/apis/sps_api/include/steem/plugins/sps_api/sps_api.hpp
+++ b/libraries/plugins/apis/sps_api/include/steem/plugins/sps_api/sps_api.hpp
@@ -7,6 +7,7 @@ namespace steem { namespace plugins { namespace sps {
   using steem::chain::account_name_type;
   using steem::chain::proposal_object;
   using steem::chain::proposal_id_type;
+  using steem::protocol::asset;
 
   namespace detail
   {
@@ -19,15 +20,47 @@ namespace steem { namespace plugins { namespace sps {
     direction_descending
   };
 
+  typedef uint64_t api_id_type;
+
+  struct api_proposal_object
+  {
+    //internal key
+    api_id_type id;
+
+    // account that created the proposal
+    account_name_type creator;
+
+    // account_being_funded
+    account_name_type receiver;
+
+    // start_date (when the proposal will begin paying out if it gets enough vote weight)
+    time_point_sec start_date;
+
+    // end_date (when the proposal expires and can no longer pay out)
+    time_point_sec end_date;
+
+    //daily_pay (the amount of SBD that is being requested to be paid out daily)
+    asset daily_pay;
+
+    //subject (a very brief description or title for the proposal)
+    string subject;
+
+    //url (a link to a page describing the work proposal in depth, generally this will probably be to a Steem post).
+    string url;
+
+    //This will be calculate every maintenance period
+    uint64_t total_votes = 0;
+  };
+
   // Struct with arguments for find_proposal methd
   struct find_proposal_args 
   {
     // id of the proposal to find
-    steem::chain::proposal_id_type id;
+    api_id_type id;
   };
 
   // Return type for find_proposal method
-  typedef std::vector<proposal_object> find_proposal_return;
+  typedef std::vector<api_proposal_object> find_proposal_return;
   
   // Struct with argumentse for list_proposals method
   struct list_proposals_args 
@@ -41,7 +74,7 @@ namespace steem { namespace plugins { namespace sps {
   };
 
   // Return type for list_proposals
-  typedef std::vector<proposal_object> list_proposals_return;
+  typedef std::vector<api_proposal_object> list_proposals_return;
   
   // Struct with arguments for list_voter_proposals methid
   struct list_voter_proposals_args 
@@ -57,7 +90,7 @@ namespace steem { namespace plugins { namespace sps {
   };
 
   // Return type for list_voter_proposals
-  typedef std::vector<proposal_object> list_voter_proposals_return;
+  typedef std::vector<api_proposal_object> list_voter_proposals_return;
   
   class sps_api
   {
@@ -80,6 +113,18 @@ namespace steem { namespace plugins { namespace sps {
 FC_REFLECT_ENUM(steem::plugins::sps::order_direction_type, 
   (direction_ascending)
   (direction_descending)
+  );
+
+FC_REFLECT(steem::plugins::sps::api_proposal_object,
+  (id)
+  (creator)
+  (receiver)
+  (start_date)
+  (end_date)
+  (daily_pay)
+  (subject)
+  (url)
+  (total_votes)
   );
 
 FC_REFLECT(steem::plugins::sps::find_proposal_args, 


### PR DESCRIPTION
Introduced api_* data types: api_proposal_object, api_id_type as a proxy for data types defined in sps_objects.hpp