### PR TITLE
[BW]: [NIP]: Prerequisites for remove_proposal_operation.

### DIFF
--- a/libraries/chain/include/steem/chain/sps_objects.hpp
+++ b/libraries/chain/include/steem/chain/sps_objects.hpp
@@ -12,8 +12,6 @@ using steem::chain::shared_string;
 using steem::chain::oid;
 using steem::chain::by_id;
 
-using namespace std;
-
 #ifndef STEEM_SPS_SPACE_ID
 #define STEEM_SPS_SPACE_ID 20
 #endif
@@ -94,8 +92,6 @@ typedef oid< proposal_vote_object > proposal_vote_id_type;
 struct by_date;
 struct by_creator;
 struct by_total_votes;
-
-using namespace boost::multi_index;
 
 typedef multi_index_container<
    proposal_object,

--- a/libraries/chain/include/steem/chain/steem_evaluator.hpp
+++ b/libraries/chain/include/steem/chain/steem_evaluator.hpp
@@ -65,4 +65,6 @@ STEEM_DEFINE_EVALUATOR( smt_create )
 #endif
 STEEM_DEFINE_EVALUATOR( create_proposal )
 STEEM_DEFINE_EVALUATOR( update_proposal_votes )
+STEEM_DEFINE_EVALUATOR( remove_proposal )
+
 } } // steem::chain

--- a/libraries/chain/sps_evaluator.cpp
+++ b/libraries/chain/sps_evaluator.cpp
@@ -52,6 +52,8 @@ void update_proposal_votes_evaluator::do_apply( const update_proposal_votes_oper
 {
    try
    {
+      ilog("voting proposal: ${op}", ("op", o));
+
       if( o.proposal_ids.empty() )
          return;
 
@@ -86,5 +88,14 @@ void update_proposal_votes_evaluator::do_apply( const update_proposal_votes_oper
    FC_CAPTURE_AND_RETHROW( (o) )
 }
 
+void remove_proposal_evaluator::do_apply(const remove_proposal_operation& op)
+{
+   try
+   {
+      ilog("Attempting to evaluate remove_proposal_operation: ${o}", ("o", op));
+
+   }
+   FC_CAPTURE_AND_RETHROW( (op) )
+}
 
 } } // steem::chain

--- a/libraries/plugins/rc/resource_count.cpp
+++ b/libraries/plugins/rc/resource_count.cpp
@@ -349,8 +349,20 @@ struct count_operation_visitor
    }
 #endif
 
-   void operator()( const create_proposal_operation& ) const {}
-   void operator()( const update_proposal_votes_operation& ) const {}
+   void operator()( const create_proposal_operation& ) const
+   {
+      FC_TODO("Change RC state bytes computation to take proposals into account");
+   }
+
+   void operator()( const update_proposal_votes_operation& ) const
+   {
+      FC_TODO("Change RC state bytes computation to take proposals into account");
+   }
+
+   void operator()(const remove_proposal_operation&) const
+   {
+      FC_TODO("Change RC state bytes computation to take proposals into account");
+   }
 
    void operator()( const recover_account_operation& ) const {}
    void operator()( const pow_operation& ) const {}

--- a/libraries/protocol/include/steem/protocol/config.hpp
+++ b/libraries/protocol/include/steem/protocol/config.hpp
@@ -318,9 +318,14 @@
 #define STEEM_TREASURY_ACCOUNT                "steem.dao"
 ///@}
 
+/// STEEM PROPOSAL SYSTEM support
+
 #define STEEM_TREASURY_FEE                         (10 * STEEM_BLOCKCHAIN_PRECISION)
 #define STEEM_PROPOSAL_MAINTENANCE_PERIOD          3600
 #define STEEM_PROPOSAL_MAINTENANCE_PERIOD_BLOCKS   (STEEM_PROPOSAL_MAINTENANCE_PERIOD / STEEM_BLOCK_INTERVAL)
+#define STEEM_PROPOSAL_SUBJECT_MAX_LENGTH          80
+/// Max number of IDs passed at once to the update_proposal_voter_operation or remove_proposal_operation.
+#define STEEM_PROPOSAL_MAX_IDS_NUMBER              5
 
 #ifdef STEEM_ENABLE_SMT
 

--- a/libraries/protocol/include/steem/protocol/operations.hpp
+++ b/libraries/protocol/include/steem/protocol/operations.hpp
@@ -97,7 +97,8 @@ namespace steem { namespace protocol {
             producer_reward_operation,
             clear_null_account_balance_operation,
             create_proposal_operation,
-            update_proposal_votes_operation
+            update_proposal_votes_operation,
+            remove_proposal_operation
          > operation;
 
    /*void operation_get_required_authorities( const operation& op,

--- a/libraries/protocol/include/steem/protocol/sps_operations.hpp
+++ b/libraries/protocol/include/steem/protocol/sps_operations.hpp
@@ -6,39 +6,60 @@
 
 namespace steem { namespace protocol {
 
-struct create_proposal_operation : base_operation
+struct create_proposal_operation : public base_operation
 {
    account_name_type creator;
+   /// Account to be paid if given proposal has sufficient votes.
    account_name_type receiver;
 
    time_point_sec start_date;
    time_point_sec end_date;
 
+   /// Amount of SBDs to be daily paid to the `receiver` account.
    asset daily_pay;
 
-   std::string subject;
+   string subject;
 
-   std::string url;
+   /// Given url shall be a valid permlink.
+   string url;
 
    void validate()const;
 
-   void get_required_posting_authorities( flat_set<account_name_type>& a )const { a.insert( creator ); }
+   void get_required_active_authorities( flat_set<account_name_type>& a )const { a.insert( creator ); }
 };
 
-struct update_proposal_votes_operation : base_operation
+struct update_proposal_votes_operation : public base_operation
 {
    account_name_type voter;
 
-   std::vector<int64_t> proposal_ids;
+   /// IDs of proposals to vote for/against. Nonexisting IDs are ignored.
+   flat_set<int64_t> proposal_ids;
 
-   bool approve;
+   bool approve = false;
 
    void validate()const;
 
-   void get_required_posting_authorities( flat_set<account_name_type>& a )const { a.insert( voter ); }
+   void get_required_active_authorities( flat_set<account_name_type>& a )const { a.insert( voter ); }
+};
+
+/** Allows to remove proposals specified by given IDs.
+    Operation can be performed only by proposal owner. 
+*/
+struct remove_proposal_operation : public base_operation
+{
+   account_name_type proposal_owner;
+
+   /// IDs of proposals to be removed. Nonexisting IDs are ignored.
+   flat_set<int64_t> proposal_ids;
+
+   void validate() const;
+
+   void get_required_active_authorities(flat_set<account_name_type>& a)const { a.insert(proposal_owner); }
 };
 
 } } // steem::protocol
 
 FC_REFLECT( steem::protocol::create_proposal_operation, (creator)(receiver)(start_date)(end_date)(daily_pay)(subject)(url) )
 FC_REFLECT( steem::protocol::update_proposal_votes_operation, (voter)(proposal_ids)(approve) )
+FC_REFLECT( steem::protocol::remove_proposal_operation, (proposal_owner)(proposal_ids) )
+

--- a/libraries/protocol/sps_operations.cpp
+++ b/libraries/protocol/sps_operations.cpp
@@ -11,13 +11,26 @@ void create_proposal_operation::validate()const
 
    FC_ASSERT( end_date > start_date, "end date must be greater than start date" );
 
+   FC_ASSERT( daily_pay.symbol.asset_num == STEEM_ASSET_NUM_SBD, "Daily pay should be expressed in SBD");
+
    FC_ASSERT( !subject.empty(), "subject is required" );
+   FC_ASSERT( subject.size() <= STEEM_PROPOSAL_SUBJECT_MAX_LENGTH, "Subject is too long");
+
    FC_ASSERT( !url.empty(), "url is required" );
+   validate_permlink(url);
 }
 
 void update_proposal_votes_operation::validate()const
 {
    validate_account_name( voter );
+   FC_ASSERT(proposal_ids.size() <= STEEM_PROPOSAL_MAX_IDS_NUMBER);
+}
+
+void remove_proposal_operation::validate() const
+{
+   validate_account_name(proposal_owner);
+   FC_ASSERT(proposal_ids.empty() == false);
+   FC_ASSERT(proposal_ids.size() <= STEEM_PROPOSAL_MAX_IDS_NUMBER);
 }
 
 } } //steem::protocol

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -2450,14 +2450,10 @@ condenser_api::legacy_signed_transaction wallet_api::follow( string follower, st
 
       auto voter = get_account(_voter);
 
-      //remove duplicates
-      std::set<int64_t> temp(_proposals.begin(), _proposals.end());
-      std::vector<int64_t> uniqu(temp.begin(), temp.end());
-
       update_proposal_votes_operation upv ;
 
       upv.voter = voter.name;
-      upv.proposal_ids = uniqu;
+      upv.proposal_ids.insert(_proposals.cbegin(), _proposals.cend());
       upv.approve = _approve;
 
       ddump((upv.voter));

--- a/tests/db_fixture/database_fixture.cpp
+++ b/tests/db_fixture/database_fixture.cpp
@@ -961,7 +961,7 @@ int64_t t_proposal_database_fixture< T >::create_proposal( std::string creator, 
    //It is necessary to find newly created object
    while( found != proposal_idx.end() && found->creator == creator )
    {
-      uint32_t val = stoi( found->subject.c_str() );
+      uint32_t val = std::stoi( found->subject.c_str() );
 
       if( val == cnt - 1 )
          return found->id;
@@ -978,7 +978,7 @@ void t_proposal_database_fixture< T >::vote_proposal( std::string voter, const s
    update_proposal_votes_operation op;
 
    op.voter = voter;
-   op.proposal_ids = id_proposals;
+   op.proposal_ids.insert(id_proposals.cbegin(), id_proposals.cend());
    op.approve = approve;
 
    signed_transaction tx;

--- a/tests/tests/proposal_tests.cpp
+++ b/tests/tests/proposal_tests.cpp
@@ -146,7 +146,7 @@ BOOST_AUTO_TEST_CASE( proposal_vote_object_apply )
       {
          BOOST_TEST_MESSAGE( "---Voting for proposal( `id_proposal_00` )---" );
          op.voter = voter_01;
-         op.proposal_ids.push_back( id_proposal_00 );
+         op.proposal_ids.insert( id_proposal_00 );
          op.approve = true;
 
          tx.operations.push_back( op );
@@ -165,7 +165,7 @@ BOOST_AUTO_TEST_CASE( proposal_vote_object_apply )
          BOOST_TEST_MESSAGE( "---Unvoting proposal( `id_proposal_00` )---" );
          op.voter = voter_01;
          op.proposal_ids.clear();
-         op.proposal_ids.push_back( id_proposal_00 );
+         op.proposal_ids.insert( id_proposal_00 );
          op.approve = false;
 
          tx.operations.push_back( op );
@@ -221,8 +221,8 @@ BOOST_AUTO_TEST_CASE( proposal_vote_object_01_apply )
       {
          BOOST_TEST_MESSAGE( "---Voting by `voter_01` for proposals( `id_proposal_00`, `id_proposal_01` )---" );
          op.voter = voter_01;
-         op.proposal_ids.push_back( id_proposal_00 );
-         op.proposal_ids.push_back( id_proposal_01 );
+         op.proposal_ids.insert( id_proposal_00 );
+         op.proposal_ids.insert( id_proposal_01 );
          op.approve = true;
 
          tx.operations.push_back( op );
@@ -250,9 +250,9 @@ BOOST_AUTO_TEST_CASE( proposal_vote_object_01_apply )
          BOOST_TEST_MESSAGE( "---Voting by `voter_02` for proposals( `id_proposal_00`, `id_proposal_01`, `id_proposal_02` )---" );
          op.voter = voter_02;
          op.proposal_ids.clear();
-         op.proposal_ids.push_back( id_proposal_02 );
-         op.proposal_ids.push_back( id_proposal_00 );
-         op.proposal_ids.push_back( id_proposal_01 );
+         op.proposal_ids.insert( id_proposal_02 );
+         op.proposal_ids.insert( id_proposal_00 );
+         op.proposal_ids.insert( id_proposal_01 );
          op.approve = true;
 
          tx.operations.push_back( op );
@@ -276,7 +276,7 @@ BOOST_AUTO_TEST_CASE( proposal_vote_object_01_apply )
          BOOST_TEST_MESSAGE( "---Voting by `voter_02` for proposals( `id_proposal_00` )---" );
          op.voter = voter_02;
          op.proposal_ids.clear();
-         op.proposal_ids.push_back( id_proposal_00 );
+         op.proposal_ids.insert( id_proposal_00 );
          op.approve = true;
 
          tx.operations.push_back( op );
@@ -300,7 +300,7 @@ BOOST_AUTO_TEST_CASE( proposal_vote_object_01_apply )
          BOOST_TEST_MESSAGE( "---Unvoting by `voter_01` proposals( `id_proposal_02` )---" );
          op.voter = voter_01;
          op.proposal_ids.clear();
-         op.proposal_ids.push_back( id_proposal_02 );
+         op.proposal_ids.insert( id_proposal_02 );
          op.approve = false;
 
          tx.operations.push_back( op );
@@ -324,7 +324,7 @@ BOOST_AUTO_TEST_CASE( proposal_vote_object_01_apply )
          BOOST_TEST_MESSAGE( "---Unvoting by `voter_01` proposals( `id_proposal_00` )---" );
          op.voter = voter_01;
          op.proposal_ids.clear();
-         op.proposal_ids.push_back( id_proposal_00 );
+         op.proposal_ids.insert( id_proposal_00 );
          op.approve = false;
 
          tx.operations.push_back( op );
@@ -348,9 +348,9 @@ BOOST_AUTO_TEST_CASE( proposal_vote_object_01_apply )
          BOOST_TEST_MESSAGE( "---Unvoting by `voter_02` proposals( `id_proposal_00`, `id_proposal_01`, `id_proposal_02` )---" );
          op.voter = voter_02;
          op.proposal_ids.clear();
-         op.proposal_ids.push_back( id_proposal_02 );
-         op.proposal_ids.push_back( id_proposal_01 );
-         op.proposal_ids.push_back( id_proposal_00 );
+         op.proposal_ids.insert( id_proposal_02 );
+         op.proposal_ids.insert( id_proposal_01 );
+         op.proposal_ids.insert( id_proposal_00 );
          op.approve = false;
 
          tx.operations.push_back( op );
@@ -374,7 +374,7 @@ BOOST_AUTO_TEST_CASE( proposal_vote_object_01_apply )
          BOOST_TEST_MESSAGE( "---Unvoting by `voter_01` proposals( `id_proposal_01` )---" );
          op.voter = voter_01;
          op.proposal_ids.clear();
-         op.proposal_ids.push_back( id_proposal_01 );
+         op.proposal_ids.insert( id_proposal_01 );
          op.approve = false;
 
          tx.operations.push_back( op );


### PR DESCRIPTION
- Defined remove_proposal_operation
- Fixed authority checks in create_proposal, update_proposal_votes_operation
- url passed to create_proposal must be valid permlink.
- defined length limits for passed proposal_ids and subject in SPS operations
- proposal_ids (in update_proposal_votes_operation and remove_proposal_operation) are stored in flat_set, to avoid redundants. Also removed unneeded copy from wallet.