### PR TITLE
Rename of  `url` member variables into `permlink` to make it better maintainable.

### DIFF
--- a/libraries/chain/include/steem/chain/sps_objects.hpp
+++ b/libraries/chain/include/steem/chain/sps_objects.hpp
@@ -33,7 +33,7 @@ class proposal_object : public object< proposal_object_type, proposal_object >
 
       template<typename Constructor, typename Allocator>
       proposal_object( Constructor&& c, allocator< Allocator > a )
-      : subject( a ), url( a )
+      : subject( a ), permlink( a )
       {
          c(*this);
       };
@@ -59,8 +59,8 @@ class proposal_object : public object< proposal_object_type, proposal_object >
       //subject (a very brief description or title for the proposal)
       shared_string subject;
 
-      //url (a link to a page describing the work proposal in depth, generally this will probably be to a Steem post).
-      shared_string url;
+      //permlink (a link to a page describing the work proposal in depth, generally this will probably be to a Steem post).
+      shared_string permlink;
 
       //This will be calculate every maintenance period
       uint64_t total_votes = 0;
@@ -142,7 +142,7 @@ typedef multi_index_container<
 
 } } // steem::chain
 
-FC_REFLECT( steem::chain::proposal_object, (id)(creator)(receiver)(start_date)(end_date)(daily_pay)(subject)(url)(total_votes) )
+FC_REFLECT( steem::chain::proposal_object, (id)(creator)(receiver)(start_date)(end_date)(daily_pay)(subject)(permlink)(total_votes) )
 CHAINBASE_SET_INDEX_TYPE( steem::chain::proposal_object, steem::chain::proposal_index )
 
 FC_REFLECT( steem::chain::proposal_vote_object, (id)(voter)(proposal_id) )

--- a/libraries/chain/sps_evaluator.cpp
+++ b/libraries/chain/sps_evaluator.cpp
@@ -31,6 +31,13 @@ void create_proposal_evaluator::do_apply( const create_proposal_operation& o )
       /// Just to check the receiver account exists.
       _db.get_account( o.receiver );
 
+      const auto* commentObject = _db.find_comment(o.creator, o.permlink);
+      if(commentObject == nullptr)
+      {
+         commentObject = _db.find_comment(o.receiver, o.permlink);
+         FC_ASSERT(commentObject != nullptr, "Proposal permlink must point to the article posted by creator or receiver");
+      }
+
       _db.create< proposal_object >( [&]( proposal_object& proposal )
       {
          proposal.creator = o.creator;
@@ -43,7 +50,7 @@ void create_proposal_evaluator::do_apply( const create_proposal_operation& o )
 
          proposal.subject = o.subject.c_str();
 
-         proposal.url = o.url.c_str();
+         proposal.permlink = o.permlink.c_str();
       });
 
       _db.adjust_balance( owner_account, -fee_sbd );

--- a/libraries/plugins/apis/condenser_api/include/steem/plugins/condenser_api/condenser_api_legacy_operations.hpp
+++ b/libraries/plugins/apis/condenser_api/include/steem/plugins/condenser_api/condenser_api_legacy_operations.hpp
@@ -410,7 +410,7 @@ namespace steem { namespace plugins { namespace condenser_api {
          end_date( op.end_date ),
          daily_pay( legacy_asset::from_asset( op.daily_pay ) ),
          subject( op.subject ),
-         url( op.url )
+         permlink( op.permlink)
       {}
 
       operator create_proposal_operation()const
@@ -422,7 +422,7 @@ namespace steem { namespace plugins { namespace condenser_api {
          op.end_date = end_date;
          op.daily_pay = daily_pay;
          op.subject = subject;
-         op.url = url;
+         op.permlink = permlink;
          return op;
       }
 
@@ -432,7 +432,7 @@ namespace steem { namespace plugins { namespace condenser_api {
       time_point_sec end_date;
       legacy_asset daily_pay;
       string subject;
-      string url;
+      string permlink;
    };
 
    struct legacy_withdraw_vesting_operation
@@ -1614,6 +1614,6 @@ FC_REFLECT( steem::plugins::condenser_api::legacy_return_vesting_delegation_oper
 FC_REFLECT( steem::plugins::condenser_api::legacy_comment_benefactor_reward_operation, (benefactor)(author)(permlink)(sbd_payout)(steem_payout)(vesting_payout) )
 FC_REFLECT( steem::plugins::condenser_api::legacy_producer_reward_operation, (producer)(vesting_shares) )
 FC_REFLECT( steem::plugins::condenser_api::legacy_claim_account_operation, (creator)(fee)(extensions) )
-FC_REFLECT( steem::plugins::condenser_api::legacy_create_proposal_operation, (creator)(receiver)(start_date)(end_date)(daily_pay)(subject)(url) )
+FC_REFLECT( steem::plugins::condenser_api::legacy_create_proposal_operation, (creator)(receiver)(start_date)(end_date)(daily_pay)(subject)(permlink) )
 
 FC_REFLECT_TYPENAME( steem::plugins::condenser_api::legacy_operation )

--- a/libraries/plugins/apis/sps_api/include/steem/plugins/sps_api/sps_api.hpp
+++ b/libraries/plugins/apis/sps_api/include/steem/plugins/sps_api/sps_api.hpp
@@ -45,7 +45,7 @@ namespace steem { namespace plugins { namespace sps {
       end_date(po.end_date),
       daily_pay(po.daily_pay),
       subject(to_string(po.subject)),
-      url(to_string(po.url)),
+      permlink(to_string(po.permlink)),
       total_votes(po.total_votes)
     {}
 
@@ -71,7 +71,7 @@ namespace steem { namespace plugins { namespace sps {
     string subject;
 
     //url (a link to a page describing the work proposal in depth, generally this will probably be to a Steem post).
-    string url;
+    string permlink;
 
     //This will be calculate every maintenance period
     uint64_t total_votes = 0;
@@ -106,9 +106,9 @@ namespace steem { namespace plugins { namespace sps {
     // sorting order (ascending or descending) of the result vector
     order_direction_type order_direction;
     // query limit
-    uint16_t limit;
+    uint16_t limit=0;
     // result will contain only data with active flag set to this value
-    int8_t active;
+    int8_t active=0;
   };
 
   // Return type for list_proposals
@@ -124,9 +124,9 @@ namespace steem { namespace plugins { namespace sps {
     // sorting order (ascending or descending) of the result vector
     order_direction_type order_direction;
     // query limit
-    uint16_t limit;
+    uint16_t limit=0;
     // result will contain only data with active flag set to this value
-    int8_t active;
+    int8_t active=0;
   };
 
   // Return type for list_voter_proposals
@@ -170,7 +170,7 @@ FC_REFLECT(steem::plugins::sps::api_proposal_object,
   (end_date)
   (daily_pay)
   (subject)
-  (url)
+  (permlink)
   (total_votes)
   );
 

--- a/libraries/plugins/rc/resource_count.cpp
+++ b/libraries/plugins/rc/resource_count.cpp
@@ -353,7 +353,7 @@ struct count_operation_visitor
    {
       state_bytes_count += _w.proposal_object_base_size;
       state_bytes_count += sizeof( op.subject );
-      state_bytes_count += sizeof( op.url );
+      state_bytes_count += sizeof( op.permlink );
       execution_time_count += _e.create_proposal_operation_exec_time;
    }
 

--- a/libraries/protocol/include/steem/protocol/sps_operations.hpp
+++ b/libraries/protocol/include/steem/protocol/sps_operations.hpp
@@ -20,8 +20,8 @@ struct create_proposal_operation : public base_operation
 
    string subject;
 
-   /// Given url shall be a valid permlink.
-   string url;
+   /// Given link shall be a valid permlink. Must be posted by creator or at least receiver.
+   string permlink;
 
    void validate()const;
 
@@ -78,7 +78,7 @@ struct proposal_pay_operation : public virtual_operation
 
 } } // steem::protocol
 
-FC_REFLECT( steem::protocol::create_proposal_operation, (creator)(receiver)(start_date)(end_date)(daily_pay)(subject)(url) )
+FC_REFLECT( steem::protocol::create_proposal_operation, (creator)(receiver)(start_date)(end_date)(daily_pay)(subject)(permlink) )
 FC_REFLECT( steem::protocol::update_proposal_votes_operation, (voter)(proposal_ids)(approve) )
 FC_REFLECT( steem::protocol::remove_proposal_operation, (proposal_owner)(proposal_ids) )
 

--- a/libraries/protocol/sps_operations.cpp
+++ b/libraries/protocol/sps_operations.cpp
@@ -16,8 +16,8 @@ void create_proposal_operation::validate()const
    FC_ASSERT( !subject.empty(), "subject is required" );
    FC_ASSERT( subject.size() <= STEEM_PROPOSAL_SUBJECT_MAX_LENGTH, "Subject is too long");
 
-   FC_ASSERT( !url.empty(), "url is required" );
-   validate_permlink(url);
+   FC_ASSERT( !permlink.empty(), "permlink is required" );
+   validate_permlink(permlink);
 }
 
 void update_proposal_votes_operation::validate()const

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -2404,7 +2404,7 @@ condenser_api::legacy_signed_transaction wallet_api::follow( string follower, st
 }
 
    condenser_api::legacy_signed_transaction  wallet_api::create_proposal(account_name_type _creator,account_name_type _receiver, time_point_sec _start_date,
-                                    time_point_sec _end_date, condenser_api::legacy_asset _daily_pay, const std::string& _subject, const std::string& _url, bool broadcast )
+                                    time_point_sec _end_date, condenser_api::legacy_asset _daily_pay, const std::string& _subject, const std::string& _permlink, bool broadcast )
    {
       auto now = time_point::now();
 
@@ -2425,7 +2425,7 @@ condenser_api::legacy_signed_transaction wallet_api::follow( string follower, st
       cp.end_date = _end_date;
       cp.daily_pay = _daily_pay;
       cp.subject = _subject;
-      cp.url = _url;
+      cp.permlink = _permlink;
 
       ddump((cp.creator));
       ddump((cp.receiver));
@@ -2433,7 +2433,7 @@ condenser_api::legacy_signed_transaction wallet_api::follow( string follower, st
       ddump((cp.end_date));
       ddump((cp.daily_pay));
       ddump((cp.subject));
-      ddump((cp.url));
+      ddump((cp.permlink));
       
       signed_transaction trx;
       trx.operations.push_back( cp );

--- a/python_scripts/tests/steempy_sps_tests/steempy_sps_tests.py
+++ b/python_scripts/tests/steempy_sps_tests/steempy_sps_tests.py
@@ -59,6 +59,9 @@ def test_create_proposal(node, account, wif):
         logger.error("Account: {} not found. {}".format("treasury", ex))
         sys.exit(1)
 
+    ret = s.commit.post("Steempy proposal title", "Steempy proposal body", creator["name"], permlink = "steempy-proposal-title", tags = "proposals")
+    print(ret)
+
     ret = s.commit.create_proposal(
       creator["name"], 
       receiver["name"], 
@@ -66,7 +69,7 @@ def test_create_proposal(node, account, wif):
       end_date,
       "16.000 TBD",
       SUBJECT,
-      "mypermlink"
+      "steempy-proposal-title"
     )
 
     assert ret["operations"][0][1]["creator"] == account
@@ -75,7 +78,7 @@ def test_create_proposal(node, account, wif):
     assert ret["operations"][0][1]["end_date"] == end_date
     assert ret["operations"][0][1]["daily_pay"] == "16.000 TBD"
     assert ret["operations"][0][1]["subject"] == SUBJECT
-    assert ret["operations"][0][1]["url"] == "mypermlink"
+    assert ret["operations"][0][1]["permlink"] == "steempy-proposal-title"
 
 def test_list_proposals(node, account, wif):
     logger.info("Testing: list_proposals")

--- a/python_scripts/tests/steempy_sps_tests/steempy_sps_tests.py
+++ b/python_scripts/tests/steempy_sps_tests/steempy_sps_tests.py
@@ -60,7 +60,6 @@ def test_create_proposal(node, account, wif):
         sys.exit(1)
 
     ret = s.commit.post("Steempy proposal title", "Steempy proposal body", creator["name"], permlink = "steempy-proposal-title", tags = "proposals")
-    print(ret)
 
     ret = s.commit.create_proposal(
       creator["name"], 

--- a/tests/db_fixture/database_fixture.cpp
+++ b/tests/db_fixture/database_fixture.cpp
@@ -949,9 +949,10 @@ int64_t t_proposal_database_fixture< T >::create_proposal( std::string creator, 
    static uint32_t cnt = 0;
    op.subject = std::to_string( cnt );
 
-   FC_TODO("Pass valid permlink here");
-
-   op.permlink = "http://" + std::to_string( cnt );
+   const std::string permlink = "permlink" + std::to_string( cnt );
+   post_comment(creator, permlink, "title", "body", "test", key);
+   
+   op.permlink = permlink;
 
    tx.operations.push_back( op );
    tx.set_expiration( this->db->head_block_time() + STEEM_MAX_TIME_UNTIL_EXPIRATION );
@@ -1172,6 +1173,27 @@ uint64_t t_proposal_database_fixture< T >::get_nr_blocks_until_maintenance_block
    return ret;
 }
 
+template< typename T>
+void t_proposal_database_fixture< T >::post_comment( std::string _authro, std::string _permlink, std::string _title, std::string _body, std::string _parent_permlink, const fc::ecc::private_key& _key)
+{
+   this->generate_blocks( this->db->head_block_time() + STEEM_MIN_ROOT_COMMENT_INTERVAL + fc::seconds( STEEM_BLOCK_INTERVAL ), true );
+   comment_operation comment;
+
+   comment.author = _authro;
+   comment.permlink = _permlink;
+   comment.title = _title;
+   comment.body = _body;
+   comment.parent_permlink = _parent_permlink;
+
+   signed_transaction trx;
+   trx.operations.push_back( comment );
+   trx.set_expiration( this->db->head_block_time() + STEEM_MAX_TIME_UNTIL_EXPIRATION );
+   this->sign( trx, _key );
+   this->db->push_transaction( trx, 0 );
+   trx.signatures.clear();
+   trx.operations.clear();
+}
+
 template int64_t t_proposal_database_fixture< clean_database_fixture >::create_proposal( std::string creator, std::string receiver, time_point_sec start_date, time_point_sec end_date, asset daily_pay, const fc::ecc::private_key& key );
 template void t_proposal_database_fixture< clean_database_fixture >::vote_proposal( std::string voter, const std::vector< int64_t >& id_proposals, bool approve, const fc::ecc::private_key& key );
 template void t_proposal_database_fixture< clean_database_fixture >::transfer_vests( std::string from, std::string to, asset amount, const fc::ecc::private_key& key );
@@ -1183,6 +1205,7 @@ template find_proposals_return t_proposal_database_fixture< clean_database_fixtu
 template void t_proposal_database_fixture< clean_database_fixture >::remove_proposal(account_name_type _deleter, flat_set<int64_t> _proposal_id, const fc::ecc::private_key& _key);
 template bool t_proposal_database_fixture< clean_database_fixture >::find_vote_for_proposal(const std::string& _user, int64_t _proposal_id);
 template uint64_t t_proposal_database_fixture< clean_database_fixture >::get_nr_blocks_until_maintenance_block();
+template void t_proposal_database_fixture< clean_database_fixture >::post_comment( std::string _authro, std::string _permlink, std::string _title, std::string _body, std::string _parent_permlink, const fc::ecc::private_key& _key);
 
 template void t_proposal_database_fixture< database_fixture >::plugin_prepare();
 template int64_t t_proposal_database_fixture< database_fixture >::create_proposal( std::string creator, std::string receiver, time_point_sec start_date, time_point_sec end_date, asset daily_pay, const fc::ecc::private_key& key );
@@ -1196,6 +1219,7 @@ template find_proposals_return t_proposal_database_fixture< database_fixture >::
 template void t_proposal_database_fixture< database_fixture >::remove_proposal(account_name_type _deleter, flat_set<int64_t> _proposal_id, const fc::ecc::private_key& _key);
 template bool t_proposal_database_fixture< database_fixture >::find_vote_for_proposal(const std::string& _user, int64_t _proposal_id);
 template uint64_t t_proposal_database_fixture< database_fixture >::get_nr_blocks_until_maintenance_block();
+template void t_proposal_database_fixture< database_fixture >::post_comment( std::string _authro, std::string _permlink, std::string _title, std::string _body, std::string _parent_permlink, const fc::ecc::private_key& _key);
 
 json_rpc_database_fixture::json_rpc_database_fixture()
 {

--- a/tests/db_fixture/database_fixture.cpp
+++ b/tests/db_fixture/database_fixture.cpp
@@ -934,6 +934,8 @@ int64_t t_proposal_database_fixture< T >::create_proposal( std::string creator, 
 {
    signed_transaction tx;
 
+   
+
    create_proposal_operation op;
 
    op.creator = creator;
@@ -946,7 +948,10 @@ int64_t t_proposal_database_fixture< T >::create_proposal( std::string creator, 
 
    static uint32_t cnt = 0;
    op.subject = std::to_string( cnt );
-   op.url = "http://" + std::to_string( cnt );
+
+   FC_TODO("Pass valid permlink here");
+
+   op.permlink = "http://" + std::to_string( cnt );
 
    tx.operations.push_back( op );
    tx.set_expiration( this->db->head_block_time() + STEEM_MAX_TIME_UNTIL_EXPIRATION );

--- a/tests/db_fixture/database_fixture.hpp
+++ b/tests/db_fixture/database_fixture.hpp
@@ -363,6 +363,8 @@ struct t_proposal_database_fixture : public T
    bool find_vote_for_proposal(const std::string& _user, int64_t _proposal_id);
 
    uint64_t get_nr_blocks_until_maintenance_block();
+
+   void post_comment( std::string _authro, std::string _permlink, std::string _title, std::string _body, std::string _parent_permlink, const fc::ecc::private_key& _key);
 };
 
 

--- a/tests/tests/proposal_tests.cpp
+++ b/tests/tests/proposal_tests.cpp
@@ -54,8 +54,9 @@ BOOST_AUTO_TEST_CASE( proposal_object_apply )
       auto daily_pay = asset( 100, SBD_SYMBOL );
 
       auto subject = "hello";
-      FC_TODO("Pass valid permlink here");
-      auto permlink = "http:://something.html";
+      auto permlink = "somethingpermlink";
+
+      post_comment(creator, permlink, "title", "body", "test", alice_private_key);
 
       FUND( creator, ASSET( "80.000 TBD" ) );
 
@@ -846,6 +847,7 @@ BOOST_AUTO_TEST_CASE( remove_proposal_001 )
       generate_block();
       FUND( cpd.creator, ASSET( "80.000 TBD" ) );
       generate_block();
+
 
       int64_t proposal_1 = create_proposal( cpd.creator, cpd.receiver, cpd.start_date, cpd.end_date, cpd.daily_pay, alice_private_key );
       int64_t proposal_2 = create_proposal( cpd.creator, cpd.receiver, cpd.start_date, cpd.end_date, cpd.daily_pay, alice_private_key );

--- a/tests/tests/proposal_tests.cpp
+++ b/tests/tests/proposal_tests.cpp
@@ -54,7 +54,8 @@ BOOST_AUTO_TEST_CASE( proposal_object_apply )
       auto daily_pay = asset( 100, SBD_SYMBOL );
 
       auto subject = "hello";
-      auto url = "http:://something.html";
+      FC_TODO("Pass valid permlink here");
+      auto permlink = "http:://something.html";
 
       FUND( creator, ASSET( "80.000 TBD" ) );
 
@@ -79,7 +80,7 @@ BOOST_AUTO_TEST_CASE( proposal_object_apply )
       op.daily_pay = daily_pay;
 
       op.subject = subject;
-      op.url = url;
+      op.permlink = permlink;
 
       tx.operations.push_back( op );
       tx.set_expiration( db->head_block_time() + STEEM_MAX_TIME_UNTIL_EXPIRATION );
@@ -111,7 +112,7 @@ BOOST_AUTO_TEST_CASE( proposal_object_apply )
       BOOST_REQUIRE( found->end_date == end_date );
       BOOST_REQUIRE( found->daily_pay == daily_pay );
       BOOST_REQUIRE( found->subject == subject );
-      BOOST_REQUIRE( found->url == url );
+      BOOST_REQUIRE( found->permlink == permlink );
 
       validate_database();
    }
@@ -576,7 +577,7 @@ BOOST_AUTO_TEST_CASE( create_proposal_005 )
       cpo.end_date   = cpo.start_date + fc::days( 2 );
       cpo.daily_pay  = asset( 100, SBD_SYMBOL );
       cpo.subject    = "";
-      cpo.url        = "http:://something.html";
+      cpo.permlink        = "http:://something.html";
       FUND( cpo.creator, ASSET( "80.000 TBD" ) );
       generate_block();
       signed_transaction tx;
@@ -605,7 +606,7 @@ BOOST_AUTO_TEST_CASE( create_proposal_006 )
       cpo.end_date   = cpo.start_date + fc::days( 2 );
       cpo.daily_pay  = asset( 100, SBD_SYMBOL );
       cpo.subject    = "very very very very very very long long long long long long subject subject subject subject subject subject";
-      cpo.url        = "http:://something.html";
+      cpo.permlink        = "http:://something.html";
       FUND( cpo.creator, ASSET( "80.000 TBD" ) );
       generate_block();
       signed_transaction tx;
@@ -634,7 +635,7 @@ BOOST_AUTO_TEST_CASE( create_proposal_007 )
       cpo.end_date   = cpo.start_date + fc::days( 2 );
       cpo.daily_pay  = asset( 100, SBD_SYMBOL );
       cpo.subject    = "subject";
-      cpo.url        = "http:://something.html";
+      cpo.permlink        = "http:://something.html";
 
       flat_set< account_name_type > auths;
       flat_set< account_name_type > expected;


### PR DESCRIPTION
Also added check in the evaluator to enforce passing valid permlink, pointing post created by proposal creator or receiver.