### PR TITLE
[BW]: [NIP] Changed version of OS running the CI build & tests to the…

### DIFF
--- a/Builder.DockerFile
+++ b/Builder.DockerFile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM phusion/baseimage:0.9.19
 
 RUN \
     apt-get update && \


### PR DESCRIPTION
Build.DockerFile uses Ubuntu 16.04 instead of 18 to match original docker environment.