### PR TITLE
Fixed version of iterate results in descending order in list_proposals

### DIFF
--- a/libraries/plugins/apis/condenser_api/condenser_api.cpp
+++ b/libraries/plugins/apis/condenser_api/condenser_api.cpp
@@ -1910,7 +1910,7 @@ namespace detail
 
    DEFINE_API_IMPL( condenser_api_impl, list_proposals )
    {
-      CHECK_ARG_SIZE( 5 )
+      FC_ASSERT( args.size() >= 5 && args.size() <= 6, "Expected #s argument(s), was 5 or 6");
       FC_ASSERT( _sps_api, "sps_api_plugin not enabled." );
 
       steem::plugins::sps::list_proposals_args list_args;
@@ -1919,6 +1919,10 @@ namespace detail
       list_args.order_direction = args[2].as<steem::plugins::sps::order_direction_type>();
       list_args.limit           = args[3].as<int>();
       list_args.status          = args[4].as<steem::plugins::sps::proposal_status>();
+      if (args.size() == 6 && args[5].as<std::string>().size() > 0)
+      {
+         list_args.last_id = args[5].as<uint64_t>();
+      }
 
       //return _sps_api->list_proposals( {args[0].as<fc::variant>, args[1].as< steem::plugins::sps::order_by_type >, args[2].as<steem::plugins::sps::order_direction_type>, args[3].as<int>, args[4].as<int>} );
       return _sps_api->list_proposals( list_args );

--- a/libraries/plugins/apis/sps_api/include/steem/plugins/sps_api/sps_api.hpp
+++ b/libraries/plugins/apis/sps_api/include/steem/plugins/sps_api/sps_api.hpp
@@ -33,44 +33,47 @@ namespace steem { namespace plugins { namespace sps {
 
   enum proposal_status : int
   {
-    active = 1,
     inactive = 0,
+    active = 1,
+    expired = 2,
     all = -1,
   };
 
-   inline order_direction_type to_order_direction(std::string _order_type)
-   {
-      std::transform(_order_type.begin(), _order_type.end(), _order_type.begin(), [](unsigned char c) {return std::tolower(c); });
-      if(_order_type == "desc")
-         return order_direction_type::direction_descending;
-      else
-         return order_direction_type::direction_ascending;
-   }
+  inline order_direction_type to_order_direction(std::string _order_type)
+  {
+    std::transform(_order_type.begin(), _order_type.end(), _order_type.begin(), [](unsigned char c) {return std::tolower(c); });
+    if(_order_type == "desc")
+        return order_direction_type::direction_descending;
+    else
+        return order_direction_type::direction_ascending;
+  }
 
-   inline order_by_type to_order_by(std::string _order_by)
-   {
-      std::transform(_order_by.begin(), _order_by.end(), _order_by.begin(), [](unsigned char c) {return std::tolower(c); });
-      if(_order_by == "start_date")
-         return order_by_type::by_start_date;
-      else if(_order_by == "end_date")
-         return order_by_type::by_end_date;
-      else if(_order_by == "total_votes")
-         return order_by_type::by_total_votes;
-      else
-         return order_by_type::by_creator; /// Consider exception throw when no constant was matched...
-   }
+  inline order_by_type to_order_by(std::string _order_by)
+  {
+    std::transform(_order_by.begin(), _order_by.end(), _order_by.begin(), [](unsigned char c) {return std::tolower(c); });
+    if(_order_by == "start_date")
+      return order_by_type::by_start_date;
+    else if(_order_by == "end_date")
+      return order_by_type::by_end_date;
+    else if(_order_by == "total_votes")
+      return order_by_type::by_total_votes;
+    else
+      return order_by_type::by_creator; /// Consider exception throw when no constant was matched...
+  }
 
-   inline proposal_status to_proposal_status(std::string _status)
-   {
-   std::transform(_status.begin(), _status.end(), _status.begin(), [](unsigned char c) {return std::tolower(c); });
+  inline proposal_status to_proposal_status(std::string _status)
+  {
+  std::transform(_status.begin(), _status.end(), _status.begin(), [](unsigned char c) {return std::tolower(c); });
 
-   if(_status == "active")
+    if(_status == "active")
       return proposal_status::active;
-   else if(_status == "inactive")
+    else if(_status == "inactive")
       return proposal_status::inactive;
-   else
+    else if(_status == "expired")
+      return proposal_status::expired;
+    else
       return proposal_status::all;  /// Consider exception throw when no constant was matched...
-   }
+  }
 
   typedef uint64_t api_id_type;
 
@@ -119,11 +122,27 @@ namespace steem { namespace plugins { namespace sps {
 
     const bool is_active(const time_point_sec &head_time) const
     {
+      return get_status(head_time) == proposal_status::active;
+    }
+
+    const proposal_status get_status(const time_point_sec &head_time) const
+    {
       if (head_time >= start_date && head_time <= end_date)
       {
-        return true;
+        return proposal_status::active;
       }
-      return false;
+
+      if (head_time < start_date)
+      {
+        return proposal_status::inactive;
+      }
+
+      if (head_time > end_date)
+      {
+        return proposal_status::expired;
+      }
+
+      FC_THROW("Unexpected status of the proposal");
     }
   };
 
@@ -150,6 +169,8 @@ namespace steem { namespace plugins { namespace sps {
     uint16_t limit = 0;
     // result will contain only data with status flag set to this value
     proposal_status status = proposal_status::all;
+    //
+    fc::optional<api_id_type> last_id;
   };
 
   // Return type for list_proposals
@@ -204,8 +225,9 @@ FC_REFLECT_ENUM(steem::plugins::sps::order_by_type,
   );
 
 FC_REFLECT_ENUM(steem::plugins::sps::proposal_status,
-  (active)
   (inactive)
+  (active)
+  (expired)
   (all)
   );
 
@@ -231,6 +253,7 @@ FC_REFLECT(steem::plugins::sps::list_proposals_args,
   (order_direction)
   (limit)
   (status)
+  (last_id)
   );
 
 FC_REFLECT(steem::plugins::sps::list_voter_proposals_args, 

--- a/libraries/plugins/apis/sps_api/sps_api.cpp
+++ b/libraries/plugins/apis/sps_api/sps_api.cpp
@@ -130,42 +130,49 @@ DEFINE_API_IMPL(sps_api_impl, list_proposals) {
         args.limit,
         _db,
         args.order_direction == sps::order_direction_type::direction_ascending,
+        (args.start.as<std::string>()).empty(),
         [&](auto& proposal) { return api_proposal_object(proposal); } 
       );
     }
     break;
     case by_start_date:
     {
+      const auto start_value = ((args.start.as<std::string>()).empty() && args.order_direction == sps::order_direction_type::direction_descending) ? time_point_sec() : args.start.as<time_point_sec>();
       steem::utilities::iterate_ordered_results<proposal_index, steem::chain::by_start_date>(
-        args.start.as<time_point_sec>(),
+        start_value,
         result,
         args.limit,
         _db,
         args.order_direction == sps::order_direction_type::direction_ascending,
+        (args.start.as<std::string>()).empty(),
         [&](auto& proposal) { return api_proposal_object(proposal); } 
       );
     }
     break;
     case by_end_date:
     {
+      const auto start_value = ((args.start.as<std::string>()).empty() && args.order_direction == sps::order_direction_type::direction_descending) ? time_point_sec() : args.start.as<time_point_sec>();
       steem::utilities::iterate_ordered_results<proposal_index, steem::chain::by_end_date>(
-        args.start.as<time_point_sec>(),
+        start_value,
         result,
         args.limit,
         _db,
         args.order_direction == sps::order_direction_type::direction_ascending,
+        (args.start.as<std::string>()).empty(),
         [&](auto& proposal) { return api_proposal_object(proposal); } 
       );
     }
     break;
     case by_total_votes:
     {
+      const auto start_value = ((args.start.as<std::string>()).empty() && args.order_direction == sps::order_direction_type::direction_descending) ? 0 : args.start.as<uint64_t>();
       steem::utilities::iterate_ordered_results<proposal_index, steem::chain::by_total_votes>(
-        args.start.as<uint64_t>(),
+        start_value,
         result,
         args.limit,
         _db,
         args.order_direction == sps::order_direction_type::direction_ascending,
+        (args.start.as<std::string>()).empty(),
         [&](auto& proposal) { return api_proposal_object(proposal); } 
       );
     }

--- a/libraries/plugins/apis/sps_api/sps_api.cpp
+++ b/libraries/plugins/apis/sps_api/sps_api.cpp
@@ -124,44 +124,48 @@ DEFINE_API_IMPL(sps_api_impl, list_proposals) {
   {
     case by_creator:
     {
-      steem::utilities::iterate_results<proposal_index, steem::chain::by_creator>(
+      steem::utilities::iterate_ordered_results<proposal_index, steem::chain::by_creator>(
         args.start.as<account_name_type>(),
         result,
         args.limit,
         _db,
+        args.order_direction == sps::order_direction_type::direction_ascending,
         [&](auto& proposal) { return api_proposal_object(proposal); } 
       );
     }
     break;
     case by_start_date:
     {
-      steem::utilities::iterate_results<proposal_index, steem::chain::by_start_date>(
+      steem::utilities::iterate_ordered_results<proposal_index, steem::chain::by_start_date>(
         args.start.as<time_point_sec>(),
         result,
         args.limit,
         _db,
+        args.order_direction == sps::order_direction_type::direction_ascending,
         [&](auto& proposal) { return api_proposal_object(proposal); } 
       );
     }
     break;
     case by_end_date:
     {
-      steem::utilities::iterate_results<proposal_index, steem::chain::by_end_date>(
+      steem::utilities::iterate_ordered_results<proposal_index, steem::chain::by_end_date>(
         args.start.as<time_point_sec>(),
         result,
         args.limit,
         _db,
+        args.order_direction == sps::order_direction_type::direction_ascending,
         [&](auto& proposal) { return api_proposal_object(proposal); } 
       );
     }
     break;
     case by_total_votes:
     {
-      steem::utilities::iterate_results<proposal_index, steem::chain::by_total_votes>(
+      steem::utilities::iterate_ordered_results<proposal_index, steem::chain::by_total_votes>(
         args.start.as<uint64_t>(),
         result,
         args.limit,
         _db,
+        args.order_direction == sps::order_direction_type::direction_ascending,
         [&](auto& proposal) { return api_proposal_object(proposal); } 
       );
     }
@@ -191,11 +195,6 @@ DEFINE_API_IMPL(sps_api_impl, list_proposals) {
     });
   }
 
-  if (!result.empty())
-  {
-    // sorting operations
-    sort_results<list_proposals_return>(result, args.order_by, args.order_direction);
-  }
   return result;
 }
 

--- a/libraries/utilities/include/steem/utilities/iterate_results.hpp
+++ b/libraries/utilities/include/steem/utilities/iterate_results.hpp
@@ -1,5 +1,6 @@
 #include <vector>
 #include <steem/chain/database.hpp>
+#include <typeinfo>
 
 namespace steem { namespace utilities {
   template<typename IndexType, typename OrderType, typename ValueType, typename ResultType, typename OnPush>
@@ -13,6 +14,37 @@ namespace steem { namespace utilities {
     {
       result.push_back( on_push( *itr ) );
       ++itr;
+    }
+  }
+
+  template<typename IndexType, typename OrderType, typename ValueType, typename ResultType, typename OnPush>
+  void iterate_ordered_results(ValueType start, std::vector<ResultType>& result, uint32_t limit, chain::database& db, bool ordered_ascending, OnPush&& on_push)
+  {
+    const auto& idx = db.get_index< IndexType, OrderType >();
+    if (ordered_ascending)
+    {
+      auto itr = idx.lower_bound( start );
+      auto end = idx.end();
+
+      while( result.size() < limit && itr != end )
+      {
+        result.push_back( on_push( *itr ) );
+        ++itr;
+      }
+    }
+    else
+    {
+      auto itr = idx.begin();
+      auto end = idx.upper_bound(start);
+
+      std::vector<ResultType> tmp;
+      while(itr != end )
+      {
+        tmp.push_back( on_push( *itr ) );
+        ++itr;
+      }
+
+      result.assign(tmp.rbegin(), ((tmp.rbegin() + limit) > tmp.rend() ? tmp.rend() : (tmp.rbegin() + limit)));
     }
   }
 }}

--- a/libraries/utilities/include/steem/utilities/iterate_results.hpp
+++ b/libraries/utilities/include/steem/utilities/iterate_results.hpp
@@ -16,4 +16,35 @@ namespace steem { namespace utilities {
       ++itr;
     }
   }
+
+  template<typename IndexType, typename OrderType, typename ValueType, typename ResultType, typename OnPush>
+  void iterate_ordered_results(ValueType start, std::vector<ResultType>& result, uint32_t limit, chain::database& db, bool ordered_ascending, OnPush&& on_push)
+  {
+    const auto& idx = db.get_index< IndexType, OrderType >();
+    if (ordered_ascending)
+    {
+      auto itr = idx.lower_bound( start );
+      auto end = idx.end();
+
+      while( result.size() < limit && itr != end )
+      {
+        result.push_back( on_push( *itr ) );
+        ++itr;
+      }
+    }
+    else
+    {
+      auto itr = idx.begin();
+      auto end = idx.upper_bound(start);
+
+      std::vector<ResultType> tmp;
+      while(itr != end )
+      {
+        tmp.push_back( on_push( *itr ) );
+        ++itr;
+      }
+
+      result.assign(tmp.rbegin(), ((tmp.rbegin() + limit) > tmp.rend() ? tmp.rend() : (tmp.rbegin() + limit)));
+    }
+  }
 }}

--- a/libraries/utilities/include/steem/utilities/iterate_results.hpp
+++ b/libraries/utilities/include/steem/utilities/iterate_results.hpp
@@ -18,33 +18,31 @@ namespace steem { namespace utilities {
   }
 
   template<typename IndexType, typename OrderType, typename ValueType, typename ResultType, typename OnPush>
-  void iterate_ordered_results(ValueType start, std::vector<ResultType>& result, uint32_t limit, chain::database& db, bool ordered_ascending, OnPush&& on_push)
+  void iterate_ordered_results(ValueType start, std::vector<ResultType>& result, uint32_t limit, chain::database& db, bool ordered_ascending, bool start_from_end, OnPush&& on_push)
   {
     const auto& idx = db.get_index< IndexType, OrderType >();
+
     if (ordered_ascending)
     {
-      auto itr = idx.lower_bound( start );
+      auto itr = idx.lower_bound(start);
       auto end = idx.end();
 
-      while( result.size() < limit && itr != end )
+      while (result.size() < limit && itr != end)
       {
-        result.push_back( on_push( *itr ) );
+        result.push_back(on_push(*itr));
         ++itr;
       }
     }
     else
     {
-      auto itr = idx.begin();
-      auto end = idx.upper_bound(start);
+      auto itr = start_from_end ? idx.rbegin() : boost::reverse_iterator<decltype(idx.upper_bound(start))>(idx.upper_bound(start));
+      auto end = idx.rend();
 
-      std::vector<ResultType> tmp;
-      while(itr != end )
+      while (result.size() < limit && itr != end)
       {
-        tmp.push_back( on_push( *itr ) );
+        result.push_back(on_push(*itr));
         ++itr;
       }
-
-      result.assign(tmp.rbegin(), ((tmp.rbegin() + limit) > tmp.rend() ? tmp.rend() : (tmp.rbegin() + limit)));
     }
   }
 }}

--- a/libraries/utilities/include/steem/utilities/iterate_results.hpp
+++ b/libraries/utilities/include/steem/utilities/iterate_results.hpp
@@ -16,33 +16,4 @@ namespace steem { namespace utilities {
       ++itr;
     }
   }
-
-  template<typename IndexType, typename OrderType, typename ValueType, typename ResultType, typename OnPush>
-  void iterate_ordered_results(ValueType start, std::vector<ResultType>& result, uint32_t limit, chain::database& db, bool ordered_ascending, bool start_from_end, OnPush&& on_push)
-  {
-    const auto& idx = db.get_index< IndexType, OrderType >();
-
-    if (ordered_ascending)
-    {
-      auto itr = idx.lower_bound(start);
-      auto end = idx.end();
-
-      while (result.size() < limit && itr != end)
-      {
-        result.push_back(on_push(*itr));
-        ++itr;
-      }
-    }
-    else
-    {
-      auto itr = start_from_end ? idx.rbegin() : boost::reverse_iterator<decltype(idx.upper_bound(start))>(idx.upper_bound(start));
-      auto end = idx.rend();
-
-      while (result.size() < limit && itr != end)
-      {
-        result.push_back(on_push(*itr));
-        ++itr;
-      }
-    }
-  }
 }}

--- a/libraries/wallet/include/steem/wallet/remote_node_api.hpp
+++ b/libraries/wallet/include/steem/wallet/remote_node_api.hpp
@@ -109,7 +109,7 @@ struct remote_node_api
    vector< market_history::bucket_object > get_market_history( uint32_t, time_point_sec, time_point_sec );
    flat_set< uint32_t > get_market_history_buckets();
 
-   steem::plugins::sps::list_proposals_return list_proposals(fc::variant _start, steem::plugins::sps::order_by_type _order_by, steem::plugins::sps::order_direction_type _order_type, int _limit, steem::plugins::sps::proposal_status _status);
+   steem::plugins::sps::list_proposals_return list_proposals(fc::variant _start, steem::plugins::sps::order_by_type _order_by, steem::plugins::sps::order_direction_type _order_type, int _limit, steem::plugins::sps::proposal_status _status, fc::optional<uint64_t> _last_id);
    steem::plugins::sps::list_voter_proposals_return list_voter_proposals(fc::variant _start, steem::plugins::sps::order_by_type _order_by, steem::plugins::sps::order_direction_type _order_type, int _limit, steem::plugins::sps::proposal_status _status);
    steem::plugins::sps::find_proposals_return find_proposals(flat_set<uint64_t> _ids);
 };

--- a/libraries/wallet/include/steem/wallet/wallet.hpp
+++ b/libraries/wallet/include/steem/wallet/wallet.hpp
@@ -1103,13 +1103,15 @@ class wallet_api
        * @param _order_by   - name a field for sorting operation,
        * @param _order_type - set print order asc - ascdending, desc - descending,
        * @param _limit      - query limit
-       * @param _status     - List only results with given status (inactive, active, all).
+       * @param _status     - List only results with given status (expired, inactive, active, all).
+       * @param _last_id    - (optional) Start search from given id.
        */
       list_proposals_return list_proposals(fc::variant _start,
                                            std::string _order_by = "creator",
                                            std::string _order_type = "desc",
                                            int _limit = 10,
-                                           std::string _status = "all");
+                                           std::string _status = "all",
+                                           std::string _last_id = "");
 
       /**
        * List proposals of given voter
@@ -1117,7 +1119,7 @@ class wallet_api
        * @param _order_by   - name a field for sorting operation,
        * @param _order_type - set print order asc - ascdending, desc - descending,
        * @param _limit      - query limit
-       * @param _status     - List only results with given status (inactive, active, all).
+       * @param _status     - List only results with given status (expired, inactive, active, all).
        */
       list_voter_proposals_return list_voter_proposals(fc::variant _start,
                                                        std::string _order_by = "creator",

--- a/libraries/wallet/remote_node_api.cpp
+++ b/libraries/wallet/remote_node_api.cpp
@@ -429,7 +429,7 @@ flat_set< uint32_t > remote_node_api::get_market_history_buckets()
    FC_ASSERT( false );
 }
 
-steem::plugins::sps::list_proposals_return remote_node_api::list_proposals(fc::variant _start, steem::plugins::sps::order_by_type _order_by, steem::plugins::sps::order_direction_type _order_type, int _limit,  steem::plugins::sps::proposal_status _status)
+steem::plugins::sps::list_proposals_return remote_node_api::list_proposals(fc::variant _start, steem::plugins::sps::order_by_type _order_by, steem::plugins::sps::order_direction_type _order_type, int _limit,  steem::plugins::sps::proposal_status _status, fc::optional<uint64_t> _last_id)
 {
    FC_ASSERT( false );
 }

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -2470,7 +2470,8 @@ condenser_api::legacy_signed_transaction wallet_api::follow( string follower, st
                                                                          std::string _order_by,
                                                                          std::string _order_type,
                                                                          int _limit,
-                                                                         std::string _status)
+                                                                         std::string _status,
+                                                                         std::string _last_id)
    {
       FC_ASSERT(!_order_by.empty());
       FC_ASSERT(!_order_type.empty());
@@ -2483,16 +2484,20 @@ condenser_api::legacy_signed_transaction wallet_api::follow( string follower, st
       args.order_direction = steem::plugins::sps::to_order_direction(_order_type);
       args.limit           = _limit;
       args.status          = steem::plugins::sps::to_proposal_status(_status);
+      if (_last_id.size() > 0)
+      {
+         args.last_id         = boost::lexical_cast<uint64_t>(_last_id);
+      }
 
       ddump((args.start));
       ddump((args.order_by));
       ddump((args.order_direction));
       ddump((args.limit));
       ddump((args.status));
+      ddump((args.last_id));
 
       try {
-         return my->_remote_api->list_proposals(args.start, args.order_by,  args.order_direction, args.limit, args.status);
-         
+         return my->_remote_api->list_proposals(args.start, args.order_by,  args.order_direction, args.limit, args.status, args.last_id);
       } catch( fc::exception& _e) {
          elog("Caught exception while executig list_proposals: ${error}",  ("error", _e));
       } catch( std::exception& _e ) {

--- a/tests/db_fixture/database_fixture.cpp
+++ b/tests/db_fixture/database_fixture.cpp
@@ -1028,7 +1028,7 @@ bool t_proposal_database_fixture< T >::exist_proposal( int64_t id )
 }
 
 template< typename T>
-list_proposals_return t_proposal_database_fixture< T >::list_proposals(fc::variant _start, std::string _order_by, std::string _order_type, int _limit, std::string _status) 
+list_proposals_return t_proposal_database_fixture< T >::list_proposals(fc::variant _start, std::string _order_by, std::string _order_type, int _limit, std::string _status, fc::optional<uint64_t> _last_id) 
 {
       auto api = appbase::app().get_plugin< steem::plugins::sps::sps_api_plugin >().api;
       steem::plugins::sps::list_proposals_args args;
@@ -1037,6 +1037,7 @@ list_proposals_return t_proposal_database_fixture< T >::list_proposals(fc::varia
       args.order_direction = steem::plugins::sps::to_order_direction(_order_type);
       args.limit           = _limit;
       args.status          = steem::plugins::sps::to_proposal_status(_status);
+      args.last_id         = _last_id;
 
       try {
          return api->list_proposals(args);
@@ -1155,7 +1156,7 @@ template void t_proposal_database_fixture< clean_database_fixture >::vote_propos
 template void t_proposal_database_fixture< clean_database_fixture >::transfer_vests( std::string from, std::string to, asset amount, const fc::ecc::private_key& key );
 template void t_proposal_database_fixture< clean_database_fixture >::transfer( std::string from, std::string to, asset amount, const fc::ecc::private_key& key );
 template bool t_proposal_database_fixture< clean_database_fixture >::exist_proposal( int64_t id );
-template list_proposals_return t_proposal_database_fixture< clean_database_fixture >::list_proposals(fc::variant _start, std::string _order_by, std::string _order_type, int _limit,  std::string _status);
+template list_proposals_return t_proposal_database_fixture< clean_database_fixture >::list_proposals(fc::variant _start, std::string _order_by, std::string _order_type, int _limit,  std::string _status, fc::optional<uint64_t> _last_id);
 template list_voter_proposals_return t_proposal_database_fixture< clean_database_fixture >::list_voter_proposals(fc::variant _start, std::string _order_by, std::string _order_type, int _limit,  std::string _status);
 template find_proposals_return t_proposal_database_fixture< clean_database_fixture >::find_proposals(flat_set<uint64_t> _proposal_ids);
 template void t_proposal_database_fixture< clean_database_fixture >::remove_proposal(account_name_type _deleter, flat_set<int64_t> _proposal_id, const fc::ecc::private_key& _key);
@@ -1169,7 +1170,7 @@ template void t_proposal_database_fixture< database_fixture >::vote_proposal( st
 template void t_proposal_database_fixture< database_fixture >::transfer_vests( std::string from, std::string to, asset amount, const fc::ecc::private_key& key );
 template void t_proposal_database_fixture< database_fixture >::transfer( std::string from, std::string to, asset amount, const fc::ecc::private_key& key );
 template bool t_proposal_database_fixture< database_fixture >::exist_proposal( int64_t id );
-template list_proposals_return t_proposal_database_fixture< database_fixture >::list_proposals(fc::variant _start, std::string _order_by, std::string _order_type, int _limit,  std::string _status);
+template list_proposals_return t_proposal_database_fixture< database_fixture >::list_proposals(fc::variant _start, std::string _order_by, std::string _order_type, int _limit,  std::string _status, fc::optional<uint64_t> _last_id);
 template list_voter_proposals_return t_proposal_database_fixture< database_fixture >::list_voter_proposals(fc::variant _start, std::string _order_by, std::string _order_type, int _limit, std::string _status) ;
 template find_proposals_return t_proposal_database_fixture< database_fixture >::find_proposals(flat_set<uint64_t> _proposal_ids);
 template void t_proposal_database_fixture< database_fixture >::remove_proposal(account_name_type _deleter, flat_set<int64_t> _proposal_id, const fc::ecc::private_key& _key);

--- a/tests/db_fixture/database_fixture.cpp
+++ b/tests/db_fixture/database_fixture.cpp
@@ -991,6 +991,7 @@ list_proposals_return sps_proposal_database_fixture::list_proposals(fc::variant 
       args.order_direction = steem::plugins::sps::to_order_direction(_order_type);
       args.limit           = _limit;
       args.status          = steem::plugins::sps::to_proposal_status(_status);
+      args.last_id         = _last_id;
 
       try {
          return api->list_proposals(args);

--- a/tests/db_fixture/database_fixture.cpp
+++ b/tests/db_fixture/database_fixture.cpp
@@ -982,8 +982,7 @@ bool sps_proposal_database_fixture::exist_proposal( int64_t id )
    return proposal_idx.find( id ) != proposal_idx.end();
 }
 
-template< typename T>
-list_proposals_return t_proposal_database_fixture< T >::list_proposals(fc::variant _start, std::string _order_by, std::string _order_type, int _limit, std::string _status, fc::optional<uint64_t> _last_id) 
+list_proposals_return sps_proposal_database_fixture::list_proposals(fc::variant _start, std::string _order_by, std::string _order_type, int _limit, std::string _status, std::string _last_id) 
 {
       auto api = appbase::app().get_plugin< steem::plugins::sps::sps_api_plugin >().api;
       steem::plugins::sps::list_proposals_args args;
@@ -992,7 +991,10 @@ list_proposals_return t_proposal_database_fixture< T >::list_proposals(fc::varia
       args.order_direction = steem::plugins::sps::to_order_direction(_order_type);
       args.limit           = _limit;
       args.status          = steem::plugins::sps::to_proposal_status(_status);
-      args.last_id         = _last_id;
+      if (_last_id.size() > 0)
+      {
+         args.last_id         = boost::lexical_cast<uint64_t>(_last_id);
+      }
 
       try {
          return api->list_proposals(args);

--- a/tests/db_fixture/database_fixture.cpp
+++ b/tests/db_fixture/database_fixture.cpp
@@ -982,7 +982,8 @@ bool sps_proposal_database_fixture::exist_proposal( int64_t id )
    return proposal_idx.find( id ) != proposal_idx.end();
 }
 
-list_proposals_return sps_proposal_database_fixture::list_proposals(fc::variant _start, std::string _order_by, std::string _order_type, int _limit, std::string _status) 
+template< typename T>
+list_proposals_return t_proposal_database_fixture< T >::list_proposals(fc::variant _start, std::string _order_by, std::string _order_type, int _limit, std::string _status, fc::optional<uint64_t> _last_id) 
 {
       auto api = appbase::app().get_plugin< steem::plugins::sps::sps_api_plugin >().api;
       steem::plugins::sps::list_proposals_args args;
@@ -991,6 +992,7 @@ list_proposals_return sps_proposal_database_fixture::list_proposals(fc::variant 
       args.order_direction = steem::plugins::sps::to_order_direction(_order_type);
       args.limit           = _limit;
       args.status          = steem::plugins::sps::to_proposal_status(_status);
+      args.last_id         = _last_id;
 
       try {
          return api->list_proposals(args);

--- a/tests/db_fixture/database_fixture.cpp
+++ b/tests/db_fixture/database_fixture.cpp
@@ -982,7 +982,8 @@ bool sps_proposal_database_fixture::exist_proposal( int64_t id )
    return proposal_idx.find( id ) != proposal_idx.end();
 }
 
-list_proposals_return sps_proposal_database_fixture::list_proposals(fc::variant _start, std::string _order_by, std::string _order_type, int _limit, std::string _status) 
+template< typename T>
+list_proposals_return t_proposal_database_fixture< T >::list_proposals(fc::variant _start, std::string _order_by, std::string _order_type, int _limit, std::string _status, fc::optional<uint64_t> _last_id) 
 {
       auto api = appbase::app().get_plugin< steem::plugins::sps::sps_api_plugin >().api;
       steem::plugins::sps::list_proposals_args args;

--- a/tests/db_fixture/database_fixture.hpp
+++ b/tests/db_fixture/database_fixture.hpp
@@ -350,7 +350,7 @@ struct sps_proposal_database_fixture : public clean_database_fixture
    void vote_proposal( std::string voter, const std::vector< int64_t >& id_proposals, bool approve, const fc::ecc::private_key& key );
 
    bool exist_proposal( int64_t id );
-   steem::plugins::sps::list_proposals_return list_proposals(fc::variant _start, std::string _order_by, std::string _order_type, int _limit, std::string _status, fc::optional<uint64_t> _last_id) ;
+   steem::plugins::sps::list_proposals_return list_proposals(fc::variant _start, std::string _order_by, std::string _order_type, int _limit, std::string _status, std::string _last_id) ;
    steem::plugins::sps::list_voter_proposals_return list_voter_proposals(fc::variant _start, std::string _order_by, std::string _order_type, int _limit, std::string _status) ;
    steem::plugins::sps::find_proposals_return find_proposals(flat_set<uint64_t> _proposal_ids);
    void remove_proposal(account_name_type _deleter, flat_set<int64_t> _proposal_id, const fc::ecc::private_key& _key);

--- a/tests/db_fixture/database_fixture.hpp
+++ b/tests/db_fixture/database_fixture.hpp
@@ -355,7 +355,7 @@ struct t_proposal_database_fixture : public T
    void transfer( std::string from, std::string to, asset amount, const fc::ecc::private_key& key );
 
    bool exist_proposal( int64_t id );
-   steem::plugins::sps::list_proposals_return list_proposals(fc::variant _start, std::string _order_by, std::string _order_type, int _limit, std::string _status) ;
+   steem::plugins::sps::list_proposals_return list_proposals(fc::variant _start, std::string _order_by, std::string _order_type, int _limit, std::string _status, fc::optional<uint64_t> _last_id) ;
    steem::plugins::sps::list_voter_proposals_return list_voter_proposals(fc::variant _start, std::string _order_by, std::string _order_type, int _limit, std::string _status) ;
    steem::plugins::sps::find_proposals_return find_proposals(flat_set<uint64_t> _proposal_ids);
    void remove_proposal(account_name_type _deleter, flat_set<int64_t> _proposal_id, const fc::ecc::private_key& _key);

--- a/tests/db_fixture/database_fixture.hpp
+++ b/tests/db_fixture/database_fixture.hpp
@@ -350,7 +350,7 @@ struct sps_proposal_database_fixture : public clean_database_fixture
    void vote_proposal( std::string voter, const std::vector< int64_t >& id_proposals, bool approve, const fc::ecc::private_key& key );
 
    bool exist_proposal( int64_t id );
-   steem::plugins::sps::list_proposals_return list_proposals(fc::variant _start, std::string _order_by, std::string _order_type, int _limit, std::string _status) ;
+   steem::plugins::sps::list_proposals_return list_proposals(fc::variant _start, std::string _order_by, std::string _order_type, int _limit, std::string _status, fc::optional<uint64_t> _last_id) ;
    steem::plugins::sps::list_voter_proposals_return list_voter_proposals(fc::variant _start, std::string _order_by, std::string _order_type, int _limit, std::string _status) ;
    steem::plugins::sps::find_proposals_return find_proposals(flat_set<uint64_t> _proposal_ids);
    void remove_proposal(account_name_type _deleter, flat_set<int64_t> _proposal_id, const fc::ecc::private_key& _key);

--- a/tests/tests/proposal_tests.cpp
+++ b/tests/tests/proposal_tests.cpp
@@ -1522,7 +1522,7 @@ BOOST_AUTO_TEST_CASE( list_proposal_001 )
             }
             for(auto direct : order_direction) {
                for(auto act : active) {
-                  auto resp = list_proposals(start, by, direct,1, act);
+                  auto resp = list_proposals(start, by, direct,1, act, "");
                   if(_empty) {
                      BOOST_REQUIRE(resp.empty());
                   } else {
@@ -1536,7 +1536,7 @@ BOOST_AUTO_TEST_CASE( list_proposal_001 )
       checker(true);
       int64_t proposal_1 = create_proposal( cpd.creator, cpd.receiver, cpd.start_date, cpd.end_date, cpd.daily_pay, alice_private_key );
       BOOST_REQUIRE(proposal_1 >= 0);
-      auto resp = list_proposals(cpd.creator, "creator", "asc", 10, "all");
+      auto resp = list_proposals(cpd.creator, "creator", "asc", 10, "all", "");
       BOOST_REQUIRE(!resp.empty());
       validate_database();
    }


### PR DESCRIPTION
* Fixed version of iterate results in descending order in list_proposals. 
* Pagination schemes working in descending order have to use last of the returned values as starting point for next iteration.
* Passing empty string as start value of descending order iterates automagically from highest stored value.