### PR TITLE
More clear message when is lack of sorting

### DIFF
--- a/libraries/protocol/include/steem/protocol/sps_operations.hpp
+++ b/libraries/protocol/include/steem/protocol/sps_operations.hpp
@@ -33,7 +33,7 @@ struct update_proposal_votes_operation : public base_operation
    account_name_type voter;
 
    /// IDs of proposals to vote for/against. Nonexisting IDs are ignored.
-   flat_set<int64_t> proposal_ids;
+   flat_set_ex<int64_t> proposal_ids;
 
    bool approve = false;
 
@@ -50,7 +50,7 @@ struct remove_proposal_operation : public base_operation
    account_name_type proposal_owner;
 
    /// IDs of proposals to be removed. Nonexisting IDs are ignored.
-   flat_set<int64_t> proposal_ids;
+   flat_set_ex<int64_t> proposal_ids;
 
    void validate() const;
 
@@ -77,6 +77,49 @@ struct proposal_pay_operation : public virtual_operation
 };
 
 } } // steem::protocol
+
+namespace fc {
+
+   namespace raw {
+       template<typename Stream, typename T>
+       inline void pack( Stream& s, const flat_set_ex<T>& value ) {
+            pack( s, static_cast< const flat_set<T>& >( value ) );
+       }
+
+       template<typename Stream, typename T>
+       inline void unpack( Stream& s, flat_set_ex<T>& value, uint32_t depth ) {
+         unpack( s, static_cast< flat_set<T>& >( value ), depth );
+       }
+
+   }
+
+   template<typename T>
+   void to_variant( const flat_set_ex<T>& var,  variant& vo )
+   {
+      to_variant( static_cast< const flat_set<T>& >( var ), vo );
+   }
+
+   template<typename T>
+   void from_variant( const variant& var, flat_set_ex<T>& vo )
+   {
+      const variants& vars = var.get_array();
+      vo.clear();
+      vo.reserve( vars.size() );
+      for( auto itr = vars.begin(); itr != vars.end(); ++itr )
+      {
+         //Items from variant have to be sorted
+         T tmp = itr->as<T>();
+         if( !vo.empty() )
+         {
+            T last = *( vo.rbegin() );
+            FC_ASSERT( tmp > last, "Items should be unique and sorted" );
+         }
+
+         vo.insert( tmp );
+      }
+   }
+   
+}
 
 FC_REFLECT( steem::protocol::create_proposal_operation, (creator)(receiver)(start_date)(end_date)(daily_pay)(subject)(permlink) )
 FC_REFLECT( steem::protocol::update_proposal_votes_operation, (voter)(proposal_ids)(approve) )

--- a/libraries/protocol/include/steem/protocol/types_fwd.hpp
+++ b/libraries/protocol/include/steem/protocol/types_fwd.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <cstdint>
 #include <fc/uint128.hpp>
+#include <boost/container/flat_set.hpp>
 
 namespace fc {
 class variant;
@@ -15,7 +16,32 @@ class legacy_steem_asset_symbol_type;
 struct legacy_steem_asset;
 } } // steem::protocol
 
+using boost::container::flat_set;
+
+template< class Key >
+class flat_set_ex: public flat_set< Key >
+{
+   public:
+
+      flat_set_ex& operator=( const flat_set< Key >& obj )
+      {
+         flat_set< Key >::operator=( obj );
+         return *this;
+      }
+
+      flat_set_ex& operator=( const flat_set_ex& obj )
+      {
+         flat_set< Key >::operator=( obj );
+         return *this;
+      }
+};
+
 namespace fc { namespace raw {
+
+template<typename Stream, typename T>
+void pack( Stream& s, const flat_set_ex<T>& value );
+template<typename Stream, typename T>
+void unpack( Stream& s, flat_set_ex<T>& value, uint32_t depth = 0 );
 
 template< typename Stream, typename Storage >
 inline void pack( Stream& s, const steem::protocol::fixed_string_impl< Storage >& u );
@@ -34,6 +60,12 @@ inline void unpack( Stream& s, steem::protocol::legacy_steem_asset_symbol_type& 
 
 } // raw
 
+template<typename T>
+void to_variant( const flat_set_ex<T>& var,  variant& vo );
+
+template<typename T>
+void from_variant( const variant& var, flat_set_ex<T>& vo );
+
 template< typename Storage >
 inline void to_variant( const steem::protocol::fixed_string_impl< Storage >& s, fc::variant& v );
 template< typename Storage >
@@ -43,5 +75,13 @@ inline void to_variant( const steem::protocol::asset_symbol_type& sym, fc::varia
 
 inline void from_variant( const fc::variant& v, steem::protocol::legacy_steem_asset& leg );
 inline void to_variant( const steem::protocol::legacy_steem_asset& leg, fc::variant& v );
+
+template<typename T> struct get_typename<flat_set_ex<T>>
+{
+   static const char* name()  {
+      static std::string n = std::string("flat_set<") + get_typename< fc::flat_set<T> >::name() + ">";
+      return n.c_str();
+   }
+};
 
 } // fc

--- a/programs/js_operation_serializer/main.cpp
+++ b/programs/js_operation_serializer/main.cpp
@@ -102,6 +102,7 @@ template<size_t N>   struct js_name<fc::array<uint8_t,N>> { static std::string n
 template<typename T> struct js_name< fc::optional<T> >    { static std::string name(){ return "optional " + js_name<T>::name(); } };
 template<typename T> struct js_name< fc::smart_ref<T> >   { static std::string name(){ return js_name<T>::name(); } };
 template<typename T> struct js_name< fc::flat_set<T> >    { static std::string name(){ return "set " + js_name<T>::name(); } };
+template<typename T> struct js_name< flat_set_ex<T> > { static std::string name(){ return "set " + js_name< fc::flat_set<T> >::name(); } };
 template<typename T> struct js_name< std::vector<T> >     { static std::string name(){ return "array " + js_name<T>::name(); } };
 template<typename T> struct js_name< fc::safe<T> > { static std::string name(){ return js_name<T>::name(); } };
 


### PR DESCRIPTION
Operations `update_proposal_votes_operation`, `remove_proposal_operation` have `proposal_ids` member, which is flat_map type. A strange message about authorization can be generated, when operation has unsorted or nonunique elements. The reason is that produced transaction will have computed different hash at its definition side (i.e. steem-js) and at blockchain side after deserialization, because order of passed elements will change. This fix generates more friendly message and disallows improper usage.